### PR TITLE
golang format tools

### DIFF
--- a/cmd/pubsub/subscription/main.go
+++ b/cmd/pubsub/subscription/main.go
@@ -17,11 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"cloud.google.com/go/pubsub"
 	"errors"
 	"flag"
 	"log"
 	"time"
+
+	"cloud.google.com/go/pubsub"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/kelseyhightower/envconfig"

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_types.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"

--- a/pkg/reconciler/pullsubscription/pullsubscription_test.go
+++ b/pkg/reconciler/pullsubscription/pullsubscription_test.go
@@ -19,9 +19,10 @@ package pullsubscription
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/knative/pkg/configmap"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/reconciler/pullsubscription/resources/names.go
+++ b/pkg/reconciler/pullsubscription/resources/names.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/GoogleCloudPlatform/cloud-run-events/pkg/apis/pubsub/v1alpha1"
 )
 

--- a/pkg/reconciler/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/pullsubscription/resources/receive_adapter.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/knative/pkg/kmeta"
 
 	"github.com/GoogleCloudPlatform/cloud-run-events/pkg/apis/pubsub/v1alpha1"

--- a/pkg/reconciler/pullsubscription/resources/subscription_ops.go
+++ b/pkg/reconciler/pullsubscription/resources/subscription_ops.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/knative/pkg/kmeta"
 
 	batchv1 "k8s.io/api/batch/v1"

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -18,8 +18,9 @@ package reconciler
 
 import (
 	"context"
-	"github.com/knative/pkg/logging"
 	"time"
+
+	"github.com/knative/pkg/logging"
 
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection/clients/dynamicclient"

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -18,9 +18,10 @@ package testing
 
 import (
 	"context"
+	"testing"
+
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/logging"
-	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
