### PR TITLE
golang format tools

### DIFF
--- a/cmd/pubsub/topic/main.go
+++ b/cmd/pubsub/topic/main.go
@@ -17,14 +17,15 @@ limitations under the License.
 package main
 
 import (
+	"flag"
+	"log"
+
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/pubsub"
-	"flag"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/context"
-	"log"
 )
 
 type envConfig struct {

--- a/pkg/apis/pubsub/v1alpha1/channel_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/channel_types_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_types_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/google/go-cmp/cmp"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
