### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_lifecycle_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_lifecycle_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/knative/pkg/apis"
 	"testing"
+
+	"github.com/knative/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
