### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/pubsub/v1alpha1/topic_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/topic_types_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/pkg/reconciler/pullsubscription/pullsubscription.go
+++ b/pkg/reconciler/pullsubscription/pullsubscription.go
@@ -19,9 +19,10 @@ package pullsubscription
 import (
 	"context"
 	"encoding/json"
-	"github.com/google/go-cmp/cmp"
 	"reflect"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/pullsubscription/pullsubscription_test.go
+++ b/pkg/reconciler/pullsubscription/pullsubscription_test.go
@@ -19,8 +19,9 @@ package pullsubscription
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
