### PR TITLE
golang format tools

### DIFF
--- a/pkg/pubsub/adapter/adapter_test.go
+++ b/pkg/pubsub/adapter/adapter_test.go
@@ -2,8 +2,9 @@ package adapter
 
 import (
 	"context"
-	cloudevents "github.com/cloudevents/sdk-go"
 	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go"
 
 	"cloud.google.com/go/pubsub"
 	cepubsub "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/pubsub"

--- a/pkg/pubsub/adapter/push.go
+++ b/pkg/pubsub/adapter/push.go
@@ -50,7 +50,7 @@ func ConvertToPush(ctx context.Context, event cloudevents.Event) cloudevents.Eve
 
 	// Grab all extensions as a string, set them as attributes payload.
 	attrs := make(map[string]string, 0)
-	for k, _ := range event.Extensions() {
+	for k := range event.Extensions() {
 		var v string
 		if err := event.ExtensionAs(k, &v); err != nil {
 			logger.Warnw("Not using extension as attribute for push payload.", zap.String("key", k))

--- a/pkg/pubsub/adapter/push_test.go
+++ b/pkg/pubsub/adapter/push_test.go
@@ -1,10 +1,11 @@
 package adapter
 
 import (
-	"cloud.google.com/go/pubsub"
 	"context"
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/google/go-cmp/cmp"
 
 	cloudevents "github.com/cloudevents/sdk-go"
 	cepubsub "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/pubsub"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
