### PR TITLE
Use desugared loggers in the pubsub main.go files

### DIFF
--- a/cmd/pubsub/receive_adapter/main.go
+++ b/cmd/pubsub/receive_adapter/main.go
@@ -51,10 +51,11 @@ type envConfig struct {
 func main() {
 	flag.Parse()
 
-	logger, _ := logging.NewLogger("", "INFO") // TODO: use logging config map.
+	sl, _ := logging.NewLogger("", "INFO") // TODO: use logging config map.
+	logger := sl.Desugar()
 	defer logger.Sync()
 
-	ctx := logging.WithLogger(signals.NewContext(), logger)
+	ctx := logging.WithLogger(signals.NewContext(), logger.Sugar())
 
 	startable := adapter.Adapter{}
 	if err := envconfig.Process("", &startable); err != nil {

--- a/cmd/pubsub/subscription/main.go
+++ b/cmd/pubsub/subscription/main.go
@@ -19,11 +19,10 @@ package main
 import (
 	"flag"
 
-	"knative.dev/pkg/signals"
-
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/signals"
 
 	"github.com/GoogleCloudPlatform/cloud-run-events/pkg/pubsub/operations"
 )
@@ -31,19 +30,20 @@ import (
 func main() {
 	flag.Parse()
 
-	logger, _ := logging.NewLogger("", "INFO") // TODO: use logging config map.
+	sl, _ := logging.NewLogger("", "INFO") // TODO: use logging config map.
+	logger := sl.Desugar()
 	defer logger.Sync()
 
-	ctx := logging.WithLogger(signals.NewContext(), logger)
+	ctx := logging.WithLogger(signals.NewContext(), logger.Sugar())
 
 	ops := operations.SubscriptionOps{}
 	if err := envconfig.Process("", &ops); err != nil {
 		logger.Fatal("Failed to process env var", zap.Error(err))
 	}
 	if err := ops.CreateClient(ctx); err != nil {
-		logger.Fatalw("Failed to create Pub/Sub Client.", zap.Error(err))
+		logger.Fatal("Failed to create Pub/Sub Client.", zap.Error(err))
 	}
 	if err := ops.Run(ctx); err != nil {
-		logger.Fatalw("Failed to run Subscription Operation.", zap.Error(err))
+		logger.Fatal("Failed to run Subscription Operation.", zap.Error(err))
 	}
 }

--- a/cmd/pubsub/topic/main.go
+++ b/cmd/pubsub/topic/main.go
@@ -32,10 +32,11 @@ import (
 func main() {
 	flag.Parse()
 
-	logger, _ := logging.NewLogger("", "INFO") // TODO: use logging config map.
+	sl, _ := logging.NewLogger("", "INFO") // TODO: use logging config map.
+	logger := sl.Desugar()
 	defer logger.Sync()
 
-	ctx := logging.WithLogger(signals.NewContext(), logger)
+	ctx := logging.WithLogger(signals.NewContext(), logger.Sugar())
 
 	ops := operations.TopicOps{}
 	if err := envconfig.Process("", &ops); err != nil {


### PR DESCRIPTION
Use desugared loggers in the pubsub main.go files, fixing (and preventing future) bugs.