### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_defaults.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_defaults.go
@@ -18,8 +18,9 @@ package v1alpha1
 
 import (
 	"context"
-	"knative.dev/pkg/ptr"
 	"time"
+
+	"knative.dev/pkg/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_defaults_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_defaults_test.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"context"
-	"knative.dev/pkg/ptr"
 	"testing"
 	"time"
+
+	"knative.dev/pkg/ptr"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_types.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_types.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	"fmt"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,7 +27,6 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	"time"
 )
 
 // +genclient

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_types_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"knative.dev/pkg/ptr"
 	"testing"
 	"time"
+
+	"knative.dev/pkg/ptr"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_validation_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_validation_test.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"context"
+	"testing"
+
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 )

--- a/pkg/reconciler/pullsubscription/resources/names.go
+++ b/pkg/reconciler/pullsubscription/resources/names.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"knative.dev/pkg/kmeta"
 
 	"github.com/GoogleCloudPlatform/cloud-run-events/pkg/apis/pubsub/v1alpha1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
