### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/messaging/v1alpha1/channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"
 )

--- a/pkg/apis/messaging/v1alpha1/register_test.go
+++ b/pkg/apis/messaging/v1alpha1/register_test.go
@@ -16,8 +16,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/apis/pubsub/v1alpha1/register_test.go
+++ b/pkg/apis/pubsub/v1alpha1/register_test.go
@@ -16,8 +16,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -18,8 +18,9 @@ package channel
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/reconciler/channel/resources/names.go
+++ b/pkg/reconciler/channel/resources/names.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/pkg/reconciler/channel/resources/pullsubscription_test.go
+++ b/pkg/reconciler/channel/resources/pullsubscription_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package resources
 
 import (
-	"knative.dev/pkg/apis"
 	"testing"
+
+	"knative.dev/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/testing/channel.go
+++ b/pkg/reconciler/testing/channel.go
@@ -18,8 +18,9 @@ package testing
 
 import (
 	"context"
-	"knative.dev/pkg/apis"
 	"time"
+
+	"knative.dev/pkg/apis"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
