### PR TITLE
Add registry property to PullSubscription CRD

### DIFF
--- a/config/300-pullsubscription.yaml
+++ b/config/300-pullsubscription.yaml
@@ -46,12 +46,24 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+        registry:
           type: object
+          description: "Internal information, users should not set this property"
+          properties:
+            eventTypes:
+              type: object
+              description: "Event types that PullSubscription can produce"
+              properties:
+                publish:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      pattern: "google.pubsub.topic.publish"
+                    schema:
+                      # TODO: set the schema. This might change based on the transformer configured?
+                      type: string
+                      pattern: ""
         spec:
           # TODO: update the OpenAPI to be much more robust.
           required:

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_types.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_types.go
@@ -156,7 +156,7 @@ const (
 
 // PubSubEventSource returns the Cloud Pub/Sub CloudEvent source value.
 func PubSubEventSource(googleCloudProject, topic string) string {
-	return fmt.Sprintf("//pubsub.googleapis.com/%s/topics/%s", googleCloudProject, topic)
+	return fmt.Sprintf("//pubsub.googleapis.com/projects/%s/topics/%s", googleCloudProject, topic)
 }
 
 const (

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_types_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestPubSubEventSource(t *testing.T) {
-	want := "//pubsub.googleapis.com/PROJECT/topics/TOPIC"
+	want := "//pubsub.googleapis.com/projects/PROJECT/topics/TOPIC"
 
 	got := PubSubEventSource("PROJECT", "TOPIC")
 


### PR DESCRIPTION
- Adding the eventTypes the PullSubscription source can produce in its CRD.
- Setting schema to empty for now, as it seems it might change based on the transformer configured. 
- Removing unnecessary apiVersion, kind, and metadata.